### PR TITLE
Multistage docker builds + charliecloud for modules currently in main.

### DIFF
--- a/runFaQCs/Dockerfile
+++ b/runFaQCs/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
-FROM continuumio/miniconda3:23.5.2-0
+FROM continuumio/miniconda3:23.5.2-0 AS build
 
-ENV container docker
+ENV container=docker
 
 # dependencies for faqcs
 RUN apt-get update -y \
@@ -12,14 +12,28 @@ RUN apt-get update -y \
 RUN conda config --add channels conda-forge \
     && conda config --add channels bioconda
 
+RUN conda init bash \
+  && . ~/.bashrc \
+  && conda create --name runFaQCs \
+  && conda activate runFaQCs 
+
 # install faqcs
-RUN conda install -c bioconda faqcs=2.10
+RUN conda install -n runFaQCs -c bioconda faqcs=2.10
+#RUN conda install -n runFaQCs -c conda-forge jellyfish
+#RUN conda install -n runFaQCs -c conda-forge zlib
+RUN conda install -c conda-forge conda-pack
 
-# add files
-# ADD runQC_subroutines/* /opt/conda/bin/runQC_subroutines/
-ADD *.wdl /opt/conda/bin/
+RUN conda-pack -n runFaQCs -o /tmp/env.tar && \
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
 
-# ENV PATH="${PATH}:/opt/conda/bin/runQC_subroutines"
+RUN /venv/bin/conda-unpack
 
-CMD ["/bin/bash"]
+FROM debian:buster AS runtime
+
+COPY --from=build /venv /venv
+ENV PATH=/venv/bin:$PATH
+    
+SHELL ["/bin/bash", "-c"]
+CMD /bin/bash
 

--- a/runFaQCs/Dockerfile
+++ b/runFaQCs/Dockerfile
@@ -29,7 +29,7 @@ RUN conda-pack -n runFaQCs -o /tmp/env.tar && \
 
 RUN /venv/bin/conda-unpack
 
-FROM debian:buster AS runtime
+FROM debian:latest AS runtime
 
 COPY --from=build /venv /venv
 ENV PATH=/venv/bin:$PATH

--- a/runFaQCs/nextflow.config
+++ b/runFaQCs/nextflow.config
@@ -1,4 +1,4 @@
-process.container = 'kaijli/runqc:1.0'
+process.container = 'apwat/run_faqcs:1.1'
 docker.enabled = true
 workflow.onComplete = {
     "rm -rf nf_assets".execute().text

--- a/runFaQCs/nextflow.config
+++ b/runFaQCs/nextflow.config
@@ -1,5 +1,5 @@
 process.container = 'apwat/run_faqcs:1.2'
-charliecloud.enabled = true //must set $NXF_CHARLIECLOUD_CACHEDIR
+singularity.enabled = true 
 workflow.onComplete = {
     "rm -rf nf_assets".execute().text
 }

--- a/runFaQCs/nextflow.config
+++ b/runFaQCs/nextflow.config
@@ -1,5 +1,5 @@
-process.container = 'apwat/run_faqcs:1.1'
-docker.enabled = true
+process.container = 'apwat/run_faqcs:1.2'
+charliecloud.enabled = true //must set $NXF_CHARLIECLOUD_CACHEDIR
 workflow.onComplete = {
     "rm -rf nf_assets".execute().text
 }

--- a/runReadsToContig/Dockerfile
+++ b/runReadsToContig/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM continuumio/miniconda3:23.5.2-0
+FROM continuumio/miniconda3:23.5.2-0 AS build
 
 ENV container=docker
 
@@ -7,20 +7,40 @@ ENV container=docker
 RUN conda config --add channels conda-forge \
     && conda config --add channels bioconda
 
-# install dependencies
-RUN conda install -c conda-forge r-base
-RUN conda install -c conda-forge python=3.11
-RUN conda install -c bioconda perl-json
-RUN conda install -c bioconda samclip=0.4.0
-RUN conda install -c bioconda bwa
-RUN conda install -c bioconda bowtie2
-RUN conda install -c bioconda samtools=1.6
+RUN conda init bash \
+    && . ~/.bashrc \
+    && conda create --name readsToContig \
+    && conda activate readsToContig 
 
-ADD bin/bam_to_fastq.pl /opt/conda/bin
-ADD bin/contig_stats.pl /opt/conda/bin
-ADD bin/ContigCoverageFold_plots_from_samPileup.pl /opt/conda/bin
-ADD bin/fastq_utility.pm /opt/conda/bin
-ADD bin/runReadsToContig.pl /opt/conda/bin
-ADD bin/tab2Json_for_dataTable.pl /opt/conda/bin
+RUN conda install -n readsToContig -c conda-forge r-base
+RUN conda install -n readsToContig -c conda-forge python=3.11
+RUN conda install -n readsToContig -c bioconda perl-json
+RUN conda install -n readsToContig -c bioconda samclip=0.4.0
+RUN conda install -n readsToContig -c bioconda bwa
+RUN conda install -n readsToContig -c bioconda bowtie2
+RUN conda install -n readsToContig -c bioconda samtools=1.6
+RUN conda install -c conda-forge conda-pack
 
-CMD ["/bin/bash"]
+
+ADD bin/bam_to_fastq.pl /opt/conda/envs/readsToContig/bin
+ADD bin/contig_stats.pl /opt/conda/envs/readsToContig/bin
+ADD bin/ContigCoverageFold_plots_from_samPileup.pl /opt/conda/envs/readsToContig/bin
+ADD bin/fastq_utility.pm /opt/conda/envs/readsToContig/bin
+ADD bin/runReadsToContig.pl /opt/conda/envs/readsToContig/bin
+ADD bin/tab2Json_for_dataTable.pl /opt/conda/envs/readsToContig/bin
+
+RUN conda-pack -n readsToContig -o /tmp/env.tar && \
+    mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+    rm /tmp/env.tar
+
+RUN /venv/bin/conda-unpack
+
+FROM debian:buster AS runtime
+#RUN apk add --no-cache bash
+
+COPY --from=build /venv /venv
+ENV PERL5LIB=/venv/lib/perl5/core_perl
+ENV PATH=/venv/bin:$PATH
+    
+SHELL ["/bin/bash", "-c"]
+CMD /bin/bash

--- a/runReadsToContig/nextflow.config
+++ b/runReadsToContig/nextflow.config
@@ -1,5 +1,5 @@
 process.container = 'apwat/run_r2c:1.3'
-docker.enabled=true
+charliecloud.enabled=true
 
 params {
     pairFile = "nf_assets/NO_FILE"

--- a/runReadsToContig/nextflow.config
+++ b/runReadsToContig/nextflow.config
@@ -1,3 +1,6 @@
+process.container = 'apwat/run_r2c:1.3'
+docker.enabled=true
+
 params {
     pairFile = "nf_assets/NO_FILE"
     unpairFile = "nf_assets/NO_FILE2"
@@ -18,5 +21,3 @@ workflow.onComplete = {
     "rm -rf nf_assets".execute().text
 }
 
-docker.enabled=true
-process.container = 'apwat/run_r2c:1.1'

--- a/runReadsToContig/nextflow.config
+++ b/runReadsToContig/nextflow.config
@@ -1,5 +1,5 @@
 process.container = 'apwat/run_r2c:1.3'
-charliecloud.enabled=true
+singularity.enabled=true
 
 params {
     pairFile = "nf_assets/NO_FILE"

--- a/runReadsToContig/runReadsToContig.nf
+++ b/runReadsToContig/runReadsToContig.nf
@@ -1,6 +1,7 @@
 #!/usr/bin/env nextflow
 
 process r2c {
+    debug true
     publishDir(
         path: "$params.outDir/AssemblyBasedAnalysis/readsMappingToContig",
         mode: 'copy'

--- a/sra2fastq/nextflow.config
+++ b/sra2fastq/nextflow.config
@@ -7,7 +7,7 @@ params {
 }
 
 process.container = 'kaijli/sra2fastq:1.6.3'
-docker.enabled = true
+charliecloud.enabled = true //must set $NXF_CHARLIECLOUD_CACHEDIR
 executor {
     submitRateLimit = '1/5sec'
 }

--- a/sra2fastq/nextflow.config
+++ b/sra2fastq/nextflow.config
@@ -7,7 +7,7 @@ params {
 }
 
 process.container = 'kaijli/sra2fastq:1.6.3'
-charliecloud.enabled = true //must set $NXF_CHARLIECLOUD_CACHEDIR
+singularity.enabled = true 
 executor {
     submitRateLimit = '1/5sec'
 }


### PR DESCRIPTION
Set up nextflow pipelines to use Charliecloud containers to provided needed software tools. 
Container images now use multistage builds to reduce size, except for sra2fastq.